### PR TITLE
[weather] `en` set as default value of $LANG

### DIFF
--- a/weather/weather
+++ b/weather/weather
@@ -2,6 +2,7 @@
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.4.0" #This version variable should not have a v but should contain all other characters ex Github release tag is v1.2.4 currentVersion is 1.2.4
+LANG="${LANG:-en}"
 locale=$(echo $LANG | cut -c1-2)
 configuredClient=""
 


### PR DESCRIPTION
Default value is set for `$LANG`

Without the default value the request to `wttr.in` was going as `.wttr.in` because of empty `$locale` variable.