### PR TITLE
Changed $1 $2 $3 etc to just $@

### DIFF
--- a/movies/movies
+++ b/movies/movies
@@ -47,7 +47,7 @@ checkInternet()
 getMovieInfo()
 {
   apiKey=946f500a # try not to abuse this it is a key that came from the ruby-scripts repo I link to.
-  movie=$(echo $1 $2 $3 $4 $5 $6 $7 $8 $9 | tr " " + ) ## format the inputs to use for the api
+  movie=$(echo $@ | tr " " + ) ## format the inputs to use for the api
   export PYTHONIOENCODING=utf8 #necessary for python2 in some cases
   movieInfo=$(httpGet "http://www.omdbapi.com/?t=$movie&apikey=$apiKey") > /dev/null # query the server and get the JSON response
   checkResponse=$(echo $movieInfo | python2 -c "import sys, json; print json.load(sys.stdin)['Response']")
@@ -167,6 +167,6 @@ elif [[ $1 == "update" ]];then
 elif [[ $1 == "help" ]];then
   usage
 else
-  getMovieInfo $1 $2 $3 $4 $5 $6 $7 $8 $9 || exit 1 ## exit if we return 1 (chances are movie was not found)
+  getMovieInfo $@ || exit 1 ## exit if we return 1 (chances are movie was not found)
   printMovieInfo ## print out the data
 fi

--- a/stocks/stocks
+++ b/stocks/stocks
@@ -183,7 +183,7 @@ elif [[ $# == "0" ]];then
   usage
   exit 0
 else
-  getTicker $1 $2 $3 $4 $5 $6 $7 $8 $9 # the company name might have spaces so passing in all args allows for this
+  getTicker $@ # the company name might have spaces so passing in all args allows for this
   getStockInformation $symbol # based on the stock symbol exrapolated by the getTicker function get information on the stock
   printStockInformation  # print this information out to the user in a human readable format
   exit 0

--- a/taste/taste
+++ b/taste/taste
@@ -91,7 +91,7 @@ update()
 getSimilar()
 {
   export PYTHONIOENCODING=utf8 #necessary for python2 in some cases
-  media=$( echo "$1 $2 $3 $4 $5 $6 $7 $8" | tr " " + )
+  media=$( echo "$@" | tr " " + )
   response=$(httpGet "https://tastedive.com/api/similar?q=$media&k=$apiKey&info=$info")
   ## Extrapolate the information by parsing the JSON
   nameOne=$(echo $response | python2 -c "import sys, json; print json.load(sys.stdin)['Similar']['Results'][0]['Name']" 2>  /dev/null || { echo "Error: Did you search a valid item?"; return 1; } )
@@ -112,7 +112,7 @@ getSimilar()
 getInfo()
 {
   export PYTHONIOENCODING=utf8 #necessary for python2 in some cases
-  media=$( echo "$1 $2 $3 $4 $5 $6 $7 $8" | tr " " + )
+  media=$( echo "$@" | tr " " + )
   response=$(httpGet "https://tastedive.com/api/similar?q=$media&k=$apiKey&info=$info")
   name=$(echo $response | python2 -c "import sys, json; print json.load(sys.stdin)['Similar']['Info'][0]['Name']")
   type=$(echo $response | python2 -c "import sys, json; print json.load(sys.stdin)['Similar']['Info'][0]['Type']")
@@ -238,14 +238,14 @@ elif [[ $1 == "help" ]];then
 else
   if [[ $search == "0" ]];then
     if [[ $info == "0" ]];then
-      getSimilar $1 $2 $3 $4 $5 $6 $7 $8 || exit 1 ## exit if we return 1 (chances are movie was not found)
+      getSimilar $@ || exit 1 ## exit if we return 1 (chances are movie was not found)
       printResults
     else
-      getSimilar $2 $3 $4 $5 $6 $7 $8 $9 || exit 1
+      getSimilar $@ || exit 1
       printResults
     fi
   else
-    getInfo $2 $3 $4 $5 $6 $7 $8 $9 || exit 1 ## exit if we return 1 (chances are movie was not found)
+    getInfo ${@:2} || exit 1 ## exit if we return 1 (chances are movie was not found)
     printInfo
   fi
 fi

--- a/weather/weather
+++ b/weather/weather
@@ -49,7 +49,8 @@ getIPWeather()
 
 getLocationWeather()
 {
-  httpGet $locale.wttr.in/$1+$2+$3+$4
+  args=$(echo $@ | tr " " + )
+  httpGet $locale.wttr.in/${args}
 }
 
 checkInternet()
@@ -158,5 +159,5 @@ elif [[ $1 == "m" ]]; then
 elif [[ $1 == "i" ]]; then
   getIPWeather "?u"
 else
-  getLocationWeather $1 $2 $3 $4
+  getLocationWeather $@
 fi


### PR DESCRIPTION
$@ is a bash variable that contains all user inputs

I wasn't going to install the "taste" script and therefore didn't get an API key, so I was unable to test it to make sure, but it should work, and the others worked (I tested the other files).

the $@ bash variable is a built in variable that holds all input to a script or function.. as apposed to listing out `$1 $2 $3 $4` etc. `${@:2}` is the same, except it starts at $2 instead of $1, which is why that is in the taste script.