### PR TITLE
Sparrow plguin for the stocks script

### DIFF
--- a/stocks/README.md
+++ b/stocks/README.md
@@ -1,0 +1,33 @@
+# SYNOPSIS
+
+Provides information about a certain stock symbol
+
+# INSTALL
+
+    sparrow plg install stocks
+
+# USAGE
+
+    sparrow plg run stocks --param name=Google
+
+
+Or if you need some automation:
+
+
+    sparrow project create utils
+    sparrow task add utils stocks-google stocks
+    sparrow task ini utils/stocks-google
+
+    name: Google
+
+
+![stocks output](https://raw.githubusercontent.com/alexanderepstein/Bash-Snippets/master/stocks/stocks.png)
+
+
+# Author
+
+* The author of main script is [Alex Epstein](https://github.com/alexanderepstein)
+* The plugin maintainer is [Alexey Melezhik](https://github.com/melezhik/)
+
+
+

--- a/stocks/README.md
+++ b/stocks/README.md
@@ -4,24 +4,29 @@ Provides information about a certain stock symbol
 
 # INSTALL
 
-    sparrow plg install stocks
+    $ sparrow plg install stocks
 
 # USAGE
 
 Basic usage:
 
-    sparrow plg run stocks --param name=Google
+    $ sparrow plg run stocks --param name=Google
 
 
 Or if you need some automation:
 
 
-    sparrow project create utils
-    sparrow task add utils stocks-google stocks
-    sparrow task ini utils/stocks-google
+    $ sparrow project create utils
 
+    $ sparrow task add utils stocks-google stocks
+
+    $ sparrow task ini utils/stocks-google
+
+    ---
     name: Google
 
+
+    $ sparrow task run utils/stocks-google
 
 # Output 
 

--- a/stocks/README.md
+++ b/stocks/README.md
@@ -8,6 +8,8 @@ Provides information about a certain stock symbol
 
 # USAGE
 
+Basic usage:
+
     sparrow plg run stocks --param name=Google
 
 
@@ -20,6 +22,8 @@ Or if you need some automation:
 
     name: Google
 
+
+# Output 
 
 ![stocks output](https://raw.githubusercontent.com/alexanderepstein/Bash-Snippets/master/stocks/stocks.png)
 

--- a/stocks/sparrow.json
+++ b/stocks/sparrow.json
@@ -1,7 +1,7 @@
 {
   "name" : "stocks",
   "description" : "Provides information about a certain stock symbol",
-  "version" : "0.0.1",
+  "version" : "0.0.2",
   "url" : "https://github.com/alexanderepstein/Bash-Snippets",
   "category": "utilities"
 }

--- a/stocks/sparrow.json
+++ b/stocks/sparrow.json
@@ -1,0 +1,7 @@
+{
+  "name" : "stocks",
+  "description" : "Provides information about a certain stock symbol",
+  "version" : "0.0.1",
+  "url" : "https://github.com/alexanderepstein/Bash-Snippets",
+  "category": "utilities"
+}

--- a/stocks/story.bash
+++ b/stocks/story.bash
@@ -1,0 +1,3 @@
+name=$(config name)
+bash $story_dir/stocks $name
+

--- a/stocks/story.bash
+++ b/stocks/story.bash
@@ -1,3 +1,4 @@
+#!/bin/bash
 name=$(config name)
 bash $story_dir/stocks $name
 

--- a/stocks/story.check
+++ b/stocks/story.check
@@ -1,0 +1,1 @@
+stock info


### PR DESCRIPTION
Based on #27

This is how it could be. I have not touched any of your data as you can see, and it seems that going this way we may install/upgrade by  either `stock -u` or  `sparrow plg install stock` (_irrespectively_) and as you see sparrow only cares about `stocks` script changes and provides kinda adapter ( wrapper ) to run the script as sparrow plugin. As long as this is true we are safe. 

This is how one can upload new version of stuck to SparrowHub

```
$ cd stocks/
$ nano sparrowfile.json # bump version
$ sparrow plg upload
```

A have released the plugin to SparrowHub so you can take it for a spin - https://sparrowhub.org/info/stocks
