### PR TITLE
Fixed bug in qrify

### DIFF
--- a/qrify/qrify
+++ b/qrify/qrify
@@ -71,7 +71,7 @@ httpGet()
 
 makeqr()
 {
-  input=$(echo $input | sed s/" "/%20/ )
+  input=$(echo $input | sed s/" "/%20/g )
   httpGet qrenco.de/$input
 }
 


### PR DESCRIPTION
The bug was that since it was `sed s/" "/%20/` instead of `sed s/" "/%20/g/' it only changed one space, so having 2 spaces would result in only one being changed.