### PR TITLE
Fixed install.sh for "Y" being default option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ askInstall()
 {
   echo -n "Do you wish to install $1 [Y/n]: "
   read -r answer
-  if [[ "$answer" == "Y" || "$answer" == "y" ]] ;then
+  if [[ "$answer" == "Y" || "$answer" == "y" || "$answer" == ""]] ;then
     cd $1 || return 1
     echo -n "Installing $1: "
     chmod a+x $1


### PR DESCRIPTION
If you don't press "Y" and then enter it will not install the script even though it says "Y" is the default here: "Do you wish to install $1 [Y/n]: ". I added empty string check so if you just press enter without saying anything it will install the script.