### PR TITLE
(feature): Add whatsmyip script to get public IP

### DIFF
--- a/whatsmyip/whatsmyip
+++ b/whatsmyip/whatsmyip
@@ -1,0 +1,2 @@
+#!/bin/bash
+curl ipinfo.io/ip


### PR DESCRIPTION
Add whatsmyip script to get public IP using a curl request to ipinfo.io/ip