### PR TITLE
Remove nc dependency

### DIFF
--- a/cheat/cheat
+++ b/cheat/cheat
@@ -38,7 +38,7 @@ httpGet()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/cloudup/cloudup
+++ b/cloudup/cloudup
@@ -26,7 +26,7 @@ getConfiguredClient()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/currency/currency
+++ b/currency/currency
@@ -129,7 +129,7 @@ checkAmount()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then
     return 0
   else

--- a/extras/Linux/maps/maps
+++ b/extras/Linux/maps/maps
@@ -38,7 +38,7 @@ httpGet()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/geo/geo
+++ b/geo/geo
@@ -177,7 +177,7 @@ update()
 
 checkInternet()
 {
-  echo "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/movies/movies
+++ b/movies/movies
@@ -55,7 +55,7 @@ httpGet()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/qrify/qrify
+++ b/qrify/qrify
@@ -84,7 +84,7 @@ makeMultiLineQr()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then
     return 0
   else

--- a/short/short
+++ b/short/short
@@ -55,7 +55,7 @@ httpGet()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/stocks/stocks
+++ b/stocks/stocks
@@ -54,7 +54,7 @@ httpGet()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/taste/taste
+++ b/taste/taste
@@ -58,7 +58,7 @@ httpGet()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/weather/weather
+++ b/weather/weather
@@ -55,7 +55,7 @@ getLocationWeather()
 
 checkInternet()
 {
-  echo "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" >/dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else

--- a/ytview/ytview
+++ b/ytview/ytview
@@ -26,7 +26,7 @@ getConfiguredClient()
 
 checkInternet()
 {
-  echo -e "GET http://google.com HTTP/1.0\n\n" | nc google.com 80 > /dev/null 2>&1 # query google with a get request
+  httpGet "http://google.com" > /dev/null 2>&1
   if [ $? -eq 0 ]; then #check if the output is 0, if so no errors have occured and we have connected to google successfully
     return 0
   else


### PR DESCRIPTION
Both curl and wget are more widely distributed than nc

Since nc is only used to check whether we can use our $configuredClient,
we can simply use that command to test for internet connectivity. In
particular, both curl and wget will fail with an exit code when the
network is disconnected