### PR TITLE
Added a different manpages directory for macOS users

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,12 @@ singleInstall()
 
 copyManpage()
 {
-  cp bash-snippets.1 /usr/local/man/man1 2>&1  || { echo "Failure"; echo "Error copying file, try running install script as sudo"; exit 1; }
+  if [[ "$(uname)" == "Darwin" ]]; then
+    manPath="/usr/local/share/man/man1"
+  else
+    manPath="/usr/local/man/man1"
+  fi
+    cp bash-snippets.1 $manPath 2>&1  || { echo "Failure"; echo "Error copying file, try running install script as sudo"; exit 1; }
 }
 
 if [[ $# == 0 ]]; then


### PR DESCRIPTION
From what I could find, the manages directory on macOS did not exist in `/usr/local/man`. Tested the change on 2 Macs and it worked fine