### PR TITLE
changes shebang to /usr/bin/env bash for better compatibility

### DIFF
--- a/cheat/cheat
+++ b/cheat/cheat
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/cloudup/cloudup
+++ b/cloudup/cloudup
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/crypt/crypt
+++ b/crypt/crypt
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/currency/currency
+++ b/currency/currency
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 base=""

--- a/extras/Linux/maps/maps
+++ b/extras/Linux/maps/maps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/geo/geo
+++ b/geo/geo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Bash utility for getting specific network info

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 currentVersion="1.13.2"
 declare -a tools=(currency stocks weather crypt movies taste short geo cheat ytview cloudup qrify siteciphers todo)

--- a/movies/movies
+++ b/movies/movies
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/qrify/qrify
+++ b/qrify/qrify
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Linyos Torovoltos github.com/linyostorovovoltos
 
 currentVersion="1.13.2"

--- a/short/short
+++ b/short/short
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/siteciphers/siteciphers
+++ b/siteciphers/siteciphers
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 DELAY=1
 configuredClient=""
 currentVersion="1.13.2"

--- a/stocks/stocks
+++ b/stocks/stocks
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/taste/taste
+++ b/taste/taste
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2"

--- a/todo/todo
+++ b/todo/todo
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 flag=""
 currentVersion="1.13.2"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 declare -a tools=(currency stocks weather crypt movies taste short geo cheat ytview cloudup qrify siteciphers todo)
 all="1"

--- a/weather/weather
+++ b/weather/weather
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Alexander Epstein https://github.com/alexanderepstein
 
 currentVersion="1.13.2" #This version variable should not have a v but should contain all other characters ex Github release tag is v1.2.4 currentVersion is 1.2.4

--- a/ytview/ytview
+++ b/ytview/ytview
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Author: Linyos Torovoltos https://github.com/linyostorovovoltos
 # Modifications: Alexander Epstein https://github.com/alexanderepstein
 


### PR DESCRIPTION
bash is not always in /bin, especially on non-Linux systems. For example, when bash is not part of the base OS install, it's likely located in /usr/local/bin. 

'#!/usr/bin/env bash' looks for bash in PATH, so it will work no matter where bash is installed.