### PR TITLE
Add -d flag for details in movies

### DIFF
--- a/movies/movies
+++ b/movies/movies
@@ -18,7 +18,6 @@ getConfiguredClient()
       echo "Error: This tool reqires either curl, wget, or fetch to be installed."
       return 1
     fi
-
 }
 
 getConfiguredPython()
@@ -66,6 +65,9 @@ getMovieInfo()
   movie=$(echo "$@" | tr " " + ) ## format the inputs to use for the api
   export PYTHONIOENCODING=utf8 #necessary for python in some cases
   movieInfo=$(httpGet "http://www.omdbapi.com/?t=$movie&apikey=$apiKey") > /dev/null # query the server and get the JSON response
+
+  # echo $movieInfo
+
   checkResponse=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Response']" 2> /dev/null)
   if [[ $checkResponse == "False" ]];then { echo "No movie found" ; return 1 ;} fi ## check to see if the movie was found
   # The rest of the code is just extrapolating the data with python from the JSON response
@@ -73,13 +75,13 @@ getMovieInfo()
   year=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Year']" 2> /dev/null)
   imdbScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][0]['Value']" 2> /dev/null)
   tomatoScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][1]['Value']" 2> /dev/null)
+  metacriticScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][2]['Value']" 2> /dev/null)
   rated=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Rated']" 2> /dev/null)
   genre=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Genre']" 2> /dev/null)
   director=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Director']" 2> /dev/null)
+  production=$(echo $production | python -c "import sys, json; print json.load(sys.stdin)['Production']" 2> /dev/null) 
   actors=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Actors']" 2> /dev/null)
   plot=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Plot']" 2> /dev/null)
-  unset movieInfo # don't need this anymore
-  unset checkResponse # don't need this anymore
 }
 
 # Prints the movie information out in a human readable format
@@ -91,9 +93,11 @@ printMovieInfo()
   echo "| Year: $year"
   if [[ $imdbScore != "" ]];then echo "| IMDB: $imdbScore";fi
   if [[ $tomatoScore != "" ]];then echo "| Tomato: $tomatoScore";fi
+  if [[ $metacriticScore != "" ]];then echo "| Metascore: $metacriticScore";fi 
   if [[ $rated != "N/A" && $rated != "" ]];then echo "| Rated: $rated";fi
   echo "| Genre: $genre"
   echo "| Director: $director"
+  echo "| Production: $production" 
   echo "| Actors: $actors"
   if [[ $plot != "N/A" && $plot != "" ]];then echo "| Plot: $plot"; fi
   echo '=================================================='

--- a/movies/movies
+++ b/movies/movies
@@ -175,11 +175,9 @@ while getopts 'ud:hv' flag; do
        exit 0 ;;
     v) echo "Version $currentVersion"
        exit 0 ;;
-    *) error "Invalid option ${flag}" 
-       exit 1 ;;
+    *) exit 1 ;;
   esac
 done
-
 
 if [[ $# == 0 ]]; then
   usage

--- a/movies/movies
+++ b/movies/movies
@@ -170,7 +170,7 @@ getConfiguredPython || exit 1
 getConfiguredClient || exit 1
 checkInternet || exit 1 # check if we have a valid internet connection if this isnt true the rest of the script will not work so stop here
 
-while getopts 'ud:hv' flag; do
+while getopts 'udhv' flag; do
   case "${flag}" in
     u) update
        exit 0 ;;
@@ -179,6 +179,8 @@ while getopts 'ud:hv' flag; do
        exit 0 ;;
     v) echo "Version $currentVersion"
        exit 0 ;;
+    :) echo "Option -$OPTARG requires an argument." >&2
+     exit 1 ;;
     *) exit 1 ;;
   esac
 done

--- a/movies/movies
+++ b/movies/movies
@@ -33,11 +33,6 @@ getConfiguredPython()
   fi
 }
 
-detail()
-{
-  detail=true
-}
-
 python()
 {
   case "$configuredPython" in
@@ -171,47 +166,17 @@ getConfiguredPython || exit 1
 getConfiguredClient || exit 1
 checkInternet || exit 1 # check if we have a valid internet connection if this isnt true the rest of the script will not work so stop here
 
-: <<'END'
-while getopts "uvhd" opt; do
-case $opt in
-  \?)
-    echo "Invalid option: -$OPTARG" >&2
-    exit 1
-  ;;
-  d)
-    detail
-  ;;  
-  h)
-    usage
-    exit 0
-  ;;
-  v)
-    echo "Version $currentVersion"
-    exit 0
-  ;;
-  u)
-    update
-    exit 0
-  ;;
-  :)
-    echo "Option -$OPTARG requires an argument." >&2
-    exit 1
-  ;;
-esac
-done
-END
-
 while getopts 'ud:hv' flag; do
   case "${flag}" in
     u) update
        exit 0 ;;
-    d) name="${OPTARG}" 
-       detail ;;
+    d) detail=true ;; 
     h) usage 
        exit 0 ;;
     v) echo "Version $currentVersion"
        exit 0 ;;
-    *) error "Invalid option ${flag}" ;;
+    *) error "Invalid option ${flag}" 
+       exit 1 ;;
   esac
 done
 

--- a/movies/movies
+++ b/movies/movies
@@ -172,7 +172,7 @@ if [[ $(uname) != "Darwin" ]];then getConfiguredPython || exit 1;fi
 getConfiguredClient || exit 1
 checkInternet || exit 1 # check if we have a valid internet connection if this isnt true the rest of the script will not work so stop here
 
-while getopts 'udhv' flag; do
+while getopts 'ud:hv' flag; do
   case "${flag}" in
     u) update
        exit 0 ;;

--- a/movies/movies
+++ b/movies/movies
@@ -70,7 +70,7 @@ getMovieInfo()
   # The rest of the code is just extrapolating the data with python from the JSON response
   title=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Title']" 2> /dev/null)
   year=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Year']" 2> /dev/null)
-  runtime=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Runtime']" 2 /dev/null) 
+  runtime=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Runtime']" 2> /dev/null)
   imdbScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][0]['Value']" 2> /dev/null)
   tomatoScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][1]['Value']" 2> /dev/null)
   metacriticScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][2]['Value']" 2> /dev/null)
@@ -78,7 +78,7 @@ getMovieInfo()
   genre=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Genre']" 2> /dev/null)
   director=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Director']" 2> /dev/null)
   production=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Production']" 2> /dev/null)
-  boxOffice=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['BoxOffice']" 2> /dev/null) 
+  boxOffice=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['BoxOffice']" 2> /dev/null)
   actors=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Actors']" 2> /dev/null)
   plot=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Plot']" 2> /dev/null)
   awards=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Awards']" 2> /dev/null)
@@ -94,15 +94,19 @@ printMovieInfo()
   echo "| Runtime: $runtime"
   if [[ $imdbScore != "" ]];then echo "| IMDB: $imdbScore"; fi
   if [[ $tomatoScore != "" ]];then echo "| Tomato: $tomatoScore"; fi
-  if $detail && [[ $metacriticScore != "" ]];then echo "| Metascore: $metacriticScore"; fi 
-  if [[ $rated != "N/A" && $rated != "" ]];then echo "| Rated: $rated"; fi
+  if $detail; then
+    if [[ $metacriticScore != "" ]]; then echo "| Metascore: $metacriticScore"; fi fi
+  if [[ $rated != "N/A" && $rated != "" ]]; then echo "| Rated: $rated"; fi
   echo "| Genre: $genre"
   echo "| Director: $director"
   echo "| Actors: $actors"
-  if [[ $plot != "N/A" && $plot != "" ]];then echo "| Plot: $plot"; fi
-  if $detail && [[ $$boxOffice != "" ]]; then echo "| Box Office: $boxOffice"; fi
-  if $detail && [[ $production != "" ]]; then echo "| Production: $production"; fi
-  if $detail && [[ $awards != "" ]]; then echo "| Awards: $awards"; fi 
+  if [[ $plot != "N/A" && $plot != "" ]]; then echo "| Plot: $plot"; fi
+  if $detail; then
+    if [[ $boxOffice != "" ]]; then echo "| Box Office: $boxOffice"; fi fi
+  if $detail; then
+    if [[ $production != "" ]]; then echo "| Production: $production"; fi fi
+  if $detail; then
+    if [[ $awards != "" ]]; then echo "| Awards: $awards"; fi fi
   echo '=================================================='
   echo
 }
@@ -156,7 +160,7 @@ usage()
   echo "  -u Update Bash-Snippet Tools"
   echo "  -h Show the help"
   echo "  -v Get the tool version"
-  echo "  -d Show detailed information" 
+  echo "  -d Show detailed information"
   echo "Examples:"
   echo "  movies Argo"
   echo "  movies Inception"
@@ -170,8 +174,8 @@ while getopts 'ud:hv' flag; do
   case "${flag}" in
     u) update
        exit 0 ;;
-    d) detail=true ;; 
-    h) usage 
+    d) detail=true ;;
+    h) usage
        exit 0 ;;
     v) echo "Version $currentVersion"
        exit 0 ;;

--- a/movies/movies
+++ b/movies/movies
@@ -4,6 +4,7 @@
 currentVersion="1.13.2"
 configuredClient=""
 configuredPython=""
+detail=false
 
 ## This function determines which http get tool the system has installed and returns an error if there isnt one
 getConfiguredClient()
@@ -32,6 +33,10 @@ getConfiguredPython()
   fi
 }
 
+detail()
+{
+  detail=true
+}
 
 python()
 {
@@ -62,26 +67,26 @@ checkInternet()
 getMovieInfo()
 {
   apiKey=946f500a # try not to abuse this it is a key that came from the ruby-scripts repo I link to.
-  movie=$(echo "$@" | tr " " + ) ## format the inputs to use for the api
+  movie=$((echo "$@" | tr " " + ) | sed 's/-d+//g' ) ## format the inputs to use for the api. Added sed command to filter -d flag.
   export PYTHONIOENCODING=utf8 #necessary for python in some cases
   movieInfo=$(httpGet "http://www.omdbapi.com/?t=$movie&apikey=$apiKey") > /dev/null # query the server and get the JSON response
-
-  # echo $movieInfo
-
   checkResponse=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Response']" 2> /dev/null)
   if [[ $checkResponse == "False" ]];then { echo "No movie found" ; return 1 ;} fi ## check to see if the movie was found
   # The rest of the code is just extrapolating the data with python from the JSON response
   title=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Title']" 2> /dev/null)
   year=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Year']" 2> /dev/null)
+  runtime=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Runtime']" 2 /dev/null) 
   imdbScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][0]['Value']" 2> /dev/null)
   tomatoScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][1]['Value']" 2> /dev/null)
   metacriticScore=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Ratings'][2]['Value']" 2> /dev/null)
   rated=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Rated']" 2> /dev/null)
   genre=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Genre']" 2> /dev/null)
   director=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Director']" 2> /dev/null)
-  production=$(echo $production | python -c "import sys, json; print json.load(sys.stdin)['Production']" 2> /dev/null) 
+  production=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Production']" 2> /dev/null)
+  boxOffice=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['BoxOffice']" 2> /dev/null) 
   actors=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Actors']" 2> /dev/null)
   plot=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Plot']" 2> /dev/null)
+  awards=$(echo $movieInfo | python -c "import sys, json; print json.load(sys.stdin)['Awards']" 2> /dev/null)
 }
 
 # Prints the movie information out in a human readable format
@@ -91,15 +96,18 @@ printMovieInfo()
   echo '=================================================='
   echo "| Title: $title"
   echo "| Year: $year"
-  if [[ $imdbScore != "" ]];then echo "| IMDB: $imdbScore";fi
-  if [[ $tomatoScore != "" ]];then echo "| Tomato: $tomatoScore";fi
-  if [[ $metacriticScore != "" ]];then echo "| Metascore: $metacriticScore";fi 
-  if [[ $rated != "N/A" && $rated != "" ]];then echo "| Rated: $rated";fi
+  echo "| Runtime: $runtime"
+  if [[ $imdbScore != "" ]];then echo "| IMDB: $imdbScore"; fi
+  if [[ $tomatoScore != "" ]];then echo "| Tomato: $tomatoScore"; fi
+  if $detail && [[ $metacriticScore != "" ]];then echo "| Metascore: $metacriticScore"; fi 
+  if [[ $rated != "N/A" && $rated != "" ]];then echo "| Rated: $rated"; fi
   echo "| Genre: $genre"
   echo "| Director: $director"
-  echo "| Production: $production" 
   echo "| Actors: $actors"
   if [[ $plot != "N/A" && $plot != "" ]];then echo "| Plot: $plot"; fi
+  if $detail && [[ $$boxOffice != "" ]]; then echo "| Box Office: $boxOffice"; fi
+  if $detail && [[ $production != "" ]]; then echo "| Production: $production"; fi
+  if $detail && [[ $awards != "" ]]; then echo "| Awards: $awards"; fi 
   echo '=================================================='
   echo
 }
@@ -153,6 +161,7 @@ usage()
   echo "  -u Update Bash-Snippet Tools"
   echo "  -h Show the help"
   echo "  -v Get the tool version"
+  echo "  -d Show detailed information" 
   echo "Examples:"
   echo "  movies Argo"
   echo "  movies Inception"
@@ -162,30 +171,50 @@ getConfiguredPython || exit 1
 getConfiguredClient || exit 1
 checkInternet || exit 1 # check if we have a valid internet connection if this isnt true the rest of the script will not work so stop here
 
-while getopts "uvh" opt; do
-  case $opt in
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      exit 1
-    ;;
-    h)
-      usage
-      exit 0
-    ;;
-    v)
-      echo "Version $currentVersion"
-      exit 0
-    ;;
-    u)
-      update
-      exit 0
-    ;;
-    :)
-      echo "Option -$OPTARG requires an argument." >&2
-      exit 1
-    ;;
+: <<'END'
+while getopts "uvhd" opt; do
+case $opt in
+  \?)
+    echo "Invalid option: -$OPTARG" >&2
+    exit 1
+  ;;
+  d)
+    detail
+  ;;  
+  h)
+    usage
+    exit 0
+  ;;
+  v)
+    echo "Version $currentVersion"
+    exit 0
+  ;;
+  u)
+    update
+    exit 0
+  ;;
+  :)
+    echo "Option -$OPTARG requires an argument." >&2
+    exit 1
+  ;;
+esac
+done
+END
+
+while getopts 'ud:hv' flag; do
+  case "${flag}" in
+    u) update
+       exit 0 ;;
+    d) name="${OPTARG}" 
+       detail ;;
+    h) usage 
+       exit 0 ;;
+    v) echo "Version $currentVersion"
+       exit 0 ;;
+    *) error "Invalid option ${flag}" ;;
   esac
 done
+
 
 if [[ $# == 0 ]]; then
   usage


### PR DESCRIPTION
Added runtime to main movies command and a -d flag for details (Metacritic score, Production office, box office revenue, and awards). Refactored the way flags are handled. This PR could possibly be written differently--my other idea was an alternate get info function for the detailed version-- but I think this is neater.