### PR TITLE
Update ytview

### DIFF
--- a/ytview/ytview
+++ b/ytview/ytview
@@ -91,7 +91,7 @@ getConfiguredPlayer()
   if [[ $(uname -s) == "Linux" ]]; then
     if command -v vlc &>/dev/null; then
       player="vlc"
-    elif  command -v mpv &>/dev/null; then
+    elif command -v mpv &>/dev/null; then
       player="mpv"
     elif command -v mplayer &>/dev/null; then
       player="mplayer"
@@ -102,10 +102,19 @@ getConfiguredPlayer()
   elif [[ $(uname -s) == "Darwin" ]]; then
     if [[ -f /Applications/VLC.app/Contents/MacOS/VLC ]]; then
       player="/Applications/VLC.app/Contents/MacOS/VLC"
+    elif [[ -f $HOME/Applications/VLC.app/Contents/MacOS/VLC ]]; then
+      player="$HOME/Applications/VLC.app/Contents/MacOS/VLC"
+    elif command -v mpv &>/dev/null; then
+      player="mpv"
+    elif [[ -f /Applications/mpv.app/Contents/MacOS/mpv ]]; then
+      player="/Applications/mpv.app/Contents/MacOS/mpv"
+    elif [[ -f $HOME/Applications/mpv.app/Contents/MacOS/mpv ]]; then
+      player="$HOME/Applications/mpv.app/Contents/MacOS/mpv"
     else
-      echo "Error: vlc is not installed and it is required to play videos" >&2
+      echo "Error: no supported video player installed (vlc or mpv)" >&2
       return 1
     fi
+  fi
   fi
 }
 


### PR DESCRIPTION
macOS additions regarding possible players

added: (1.a) `mpv` (command) ; (1.b) mpv (.app) ; (2) `$HOME/Applications` directory path for both VLC & mpv (should actually be the default Applications directory for user drag & drop installations)

Tested & working on my system (El Capitan 10.11.6)

notes: (1) playback using the new [**IINA**](https://github.com/lhc70000/iina) software doesn't work (yet), but might in the future ; (2) there's also `mplayer` (command) for macOS (via homebrew), and it would probably work, too, but I couldn't test it -- my ffmpeg hasn't been compiled with openssl & gnutls, and YouTube is only via TLS, I believe.

PS: some Mac users also leave their apps in the ~/Downloads folder, put them into subfolders in /Applications etc., so for these cases you might want to think about adding a Spotlight search to get the path to the VLC & mpv apps:

```
mdfind kMDItemCFBundleIdentifier = "org.videolan.vlc"
mdfind kMDItemCFBundleIdentifier = "io.mpv"
```

…gets the path to the .app bundle, so you just need to add `/Contents/MacOS/<ExecutableName>` to the path.

This wouldn't work, however, if users have disabled Spotlight, or if the software is freshly installed, and the Spotlight index hasn't been updated yet.

**Pull Request Label:**
* [ ] Bug
* [ ] New feature
* [x] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [ ] Have you ran the tests locally with `bats tests`?

-----