### PR TITLE
ytview update: mdfind

### DIFF
--- a/ytview/ytview
+++ b/ytview/ytview
@@ -100,19 +100,35 @@ getConfiguredPlayer()
       return 1
     fi
   elif [[ $(uname -s) == "Darwin" ]]; then
-    if [[ -f /Applications/VLC.app/Contents/MacOS/VLC ]]; then
-      player="/Applications/VLC.app/Contents/MacOS/VLC"
-    elif [[ -f $HOME/Applications/VLC.app/Contents/MacOS/VLC ]]; then
-      player="$HOME/Applications/VLC.app/Contents/MacOS/VLC"
-    elif command -v mpv &>/dev/null; then
-      player="mpv"
-    elif [[ -f /Applications/mpv.app/Contents/MacOS/mpv ]]; then
-      player="/Applications/mpv.app/Contents/MacOS/mpv"
-    elif [[ -f $HOME/Applications/mpv.app/Contents/MacOS/mpv ]]; then
-      player="$HOME/Applications/mpv.app/Contents/MacOS/mpv"
-    else
-      echo "Error: no supported video player installed (vlc or mpv)" >&2
-      return 1
+    mac_player=false
+  	if [[ $(mdutil -s / | grep "Indexing enabled." 2>/dev/null) != "" ]]; then
+  		vlc_md=$(mdfind kMDItemCFBundleIdentifier = "org.videolan.vlc" 2>/dev/null)
+  		if [[ $vlc_md != "" ]]; then
+  			player="$vlc_md/Contents/MacOS/VLC"
+  			mac_player=true
+  		else
+  			mpv_md=$(mdfind kMDItemCFBundleIdentifier = "io.mpv" 2>/dev/null)
+  			if [[ $mpv_md != "" ]]; then
+  				player="$mpv_md/Contents/MacOS/mpv"
+  				mac_player=true
+  			fi
+  		fi
+  	fi
+  	if ! $mac_player ; then
+      if [[ -f /Applications/VLC.app/Contents/MacOS/VLC ]]; then
+        player="/Applications/VLC.app/Contents/MacOS/VLC"
+      elif [[ -f $HOME/Applications/VLC.app/Contents/MacOS/VLC ]]; then
+        player="$HOME/Applications/VLC.app/Contents/MacOS/VLC"
+      elif command -v mpv &>/dev/null; then
+        player="mpv"
+      elif [[ -f /Applications/mpv.app/Contents/MacOS/mpv ]]; then
+        player="/Applications/mpv.app/Contents/MacOS/mpv"
+      elif [[ -f $HOME/Applications/mpv.app/Contents/MacOS/mpv ]]; then
+        player="$HOME/Applications/mpv.app/Contents/MacOS/mpv"
+      else
+        echo "Error: no supported video player installed (vlc or mpv)" >&2
+        return 1
+      fi
     fi
   fi
 }


### PR DESCRIPTION
Note: tried to include mdfind into the original if/elif statements first, but for that to work, we would need to write the mdfind stdouts into variables *within* the relevant if statements, and to my knowledge that's not possible with bash.

Therefore: mac_player helper variable which comes into play, if user has disabled Spotlight, or if he hasn't installed the .app versions of VLC or mpv. Then the original if/elif statements are run.

PS: maybe it's also possible to add a `-d` option for "direct play", i.e. you specify a full youtube.com or shortened youtu.be URL, or even the video ID, e.g. `ytview -d wRMXTvsCBwQ`

PPS: haven't looked into it, but I haven't seen a way to exit the user selection prompt at the end of a search list; maybe inputting anything other than integers would exit the script. (?)

PPPS: will also test mplayer on macOS at some point; have to recompile ffmpeg first

**Pull Request Label:**
* [ ] Bug
* [ ] New feature
* [x] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [ ] Have you ran the tests locally with `bats tests`?

-----
