### PR TITLE
Fixed support for single-word strings

### DIFF
--- a/qrify/qrify
+++ b/qrify/qrify
@@ -125,7 +125,6 @@ do
     u) checkInternet && update && exit 0 || exit 1 ;;
     h) usage && exit 0 ;;
     m) multiline="1" && echo "Error this is not a supported feature yet" && exit 1 ;;
-    *) usage && exit 0 ;;
   esac
 done
 
@@ -141,8 +140,10 @@ elif [[ $# == "1" ]];then
     update || exit 1
     exit 0
   else
-    usage
-    exit 1
+		checkInternet || exit 1
+    input=$(printf '%s ' "$@")
+    makeqr || exit 1
+    exit 0
   fi
 else
   if [[ $multiline == "0" ]]; then


### PR DESCRIPTION
Earlier Qrify didn't work for strings of single words (even URLs). So the command- qrify google.com displayed the help section. This has been fixed. <br/>

Earlier-<br/>
![image](https://user-images.githubusercontent.com/26690084/32447922-7c2750b8-c333-11e7-9054-28633f7c195c.png)
<br/>After implementing the fix-<br/>
![image](https://user-images.githubusercontent.com/26690084/32447963-97eff8d6-c333-11e7-8a1c-f79966a51351.png)


**Pull Request Label:**
* [x] Bug
* [ ] New feature
* [ ] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [ ] Have you ran the tests locally with `bats tests`?

-----