### PR TITLE
If task description is long, truncate it while displaying list of tasks it so that lines do not wrap

### DIFF
--- a/todo/todo
+++ b/todo/todo
@@ -144,8 +144,23 @@ getTasks()
         echo "$tempTask). $task"  >> ~/.todo/getTemp.txt
         count=$(( $count + 1 ))
       done
-      cat ~/.todo/getTemp.txt | column -t -s ";"
+      # if task description is long, we truncate it so that lines do not wrap 
+      tty_str=$(tty)
+      term_width=$(stty -a <"$tty_str" | grep -Po '(?<=columns )\d+')
+      cat ~/.todo/getTemp.txt | while read tline; do
+        task=$(echo "$tline" | cut -d ";" -f 1)
+        task_len=${#task}
+        date_str=$(echo "$tline" | cut -d ";" -f 2)
+        date_str_len=${#date_str}
+        if [[ $(( $task_len + $date_str_len + 1 )) -ge $term_width ]]; then
+          max_task_len=$(( $term_width - $date_str_len - 2))
+          task=$(echo "$task" | cut -c-${max_task_len})
+        fi
+        echo "$task;$date_str" >> ~/.todo/getTemp2.txt
+      done
+      cat ~/.todo/getTemp2.txt | column -t -s ";"
       rm -f ~/.todo/getTemp.txt
+      rm -f ~/.todo/getTemp2.txt
     fi
   else
     echo "No tasks found"


### PR DESCRIPTION
**Pull Request Label:**
* [ ] Bug
* [ ] New feature
* [X] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [X] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [X] Have you ran the tests locally with `bats tests`?

-----
Per title, if I add a task with long description, the lines in the task listing are wrapping which makes it unreadable. I've modified listing tasks (-g) accounting for terminal width and truncating description so that lines do not wrap (if you want to see full description, you can always widen the console).
