### PR TITLE
Updates to tests

### DIFF
--- a/bak2dvd/bak2dvd
+++ b/bak2dvd/bak2dvd
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Author: Charles Oblender https://github.com/oblende
-currentVersion="1.1.6"
+currentVersion="1.22.1"
 configuredClient=""
 
 tarwrite() {
@@ -551,7 +551,8 @@ while test $# -gt 0; do
     -v)  echo "Version $currentVersion"
         exit 0
         ;;
-    -u)  getConfiguredClient || exit 1
+    -u|update)
+	getConfiguredClient || exit 1
         checkInternet || exit 1
         update
         exit 0

--- a/skeleton
+++ b/skeleton
@@ -35,7 +35,7 @@ update()
 {
   # Author: Alexander Epstein https://github.com/alexanderepstein
   # Update utility version 1.2.0
-  # To test the tool enter in the defualt values that are in the examples for each variable
+  # To test the tool enter in the default values that are in the examples for each variable
   repositoryName="Bash-Snippets" #Name of repostiory to be updated ex. Sandman-Lite
   githubUserName="alexanderepstein" #username that hosts the repostiory ex. alexanderepstein
   nameOfInstallFile="install.sh" # change this if the installer file has a different name be sure to include file extension if there is one

--- a/skeleton.bats
+++ b/skeleton.bats
@@ -26,37 +26,54 @@ setup() {
   if [[ "$(uname)" == "Linux" ]]; then
     run "${TOOL_DIR}/${TOOL_NAME}" update
     [[ "$status" -eq 0 ]]
-    [[ "$output" = "Bash-Snippets is already the latest version" ]]
+    [ "$output" == "Bash-Snippets is already the latest version" ]
+  fi
+}
+
+@test "The -h option should print usage" {
+  run "${TOOL_DIR}/${TOOL_NAME}" -h
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
   fi
 }
 
 @test "No arguments prints usage instructions" {
   run "${TOOL_DIR}/${TOOL_NAME}"
   [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
-}
-
-@test "The -h option should print usage" {
-  run "${TOOL_DIR}/${TOOL_NAME}" -h
-  [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
 }
 
 @test "Get the tools version with -v" {
   run "${TOOL_DIR}/${TOOL_NAME}" -v
   [[ "$status" -eq 0 ]]
-  [[ "printf '%s\n' ${lines[0]}" =~ 'Version' ]]
+  expected='Version'
+  [[ "${output}" =~ "${expected}" ]]
 }
+
 
 # Tool specific tests
 @test "Do that cool thing" {
   run "${TOOL_DIR}/${TOOL_NAME}" cool
   [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" =~ 'This is awesome' ]]
+  expected='This is awesome'
+  [[ "${output}" =~ "${expected}" ]]
 }
 
 @test "Testing coolness factor" {
   run "${TOOL_DIR}/${TOOL_NAME}" cool --even-cooler
   [[ "$status" -eq 0 ]]
-  [[ "printf '%s\n' ${lines[1]}" =~ 'subzero' ]]
+  expected='subzero'
+  [[ "printf '%s\n' ${lines[1]}" =~ "${expected}" ]]
 }
+

--- a/skeleton.bats
+++ b/skeleton.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 
-export TOOL_NAME='cheat'
+export TOOL_NAME='skeleton'
 
 setup() {
-  # $REPO_DIR/tests/tool.bats
+  # $REPO_DIR/tests/skeleton.bats
   REPO_DIR="$( cd "$( dirname "${BATS_TEST_DIRNAME}")" >/dev/null 2>&1 && pwd)"
   TOOL_DIR="$( cd "${REPO_DIR}/${TOOL_NAME}" >/dev/null 2>&1 && pwd)"
 }
@@ -48,14 +48,15 @@ setup() {
   [[ "printf '%s\n' ${lines[0]}" =~ 'Version' ]]
 }
 
-@test "Grabbing information on a programming language (rust)" {
-  run "${TOOL_DIR}/${TOOL_NAME}" rust
+# Tool specific tests
+@test "Do that cool thing" {
+  run "${TOOL_DIR}/${TOOL_NAME}" cool
   [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" =~ 'Rust is a systems' ]]
+  [[ "${lines[0]}" =~ 'This is awesome' ]]
 }
 
-@test "Testing unkown topic due to misspelling" {
-  run "${TOOL_DIR}/${TOOL_NAME}" suuuper thiingsa
+@test "Testing coolness factor" {
+  run "${TOOL_DIR}/${TOOL_NAME}" cool --even-cooler
   [[ "$status" -eq 0 ]]
-  [[ "printf '%s\n' ${lines[1]}" =~ 'Unknown' ]]
+  [[ "printf '%s\n' ${lines[1]}" =~ 'subzero' ]]
 }

--- a/tests/bak2dvd.bats
+++ b/tests/bak2dvd.bats
@@ -1,8 +1,9 @@
 #!/usr/bin/env bats
+#
 export TOOL_NAME='bak2dvd'
 
 setup() {
-  # $REPO_DIR/tests/skeleton.bats
+  # $REPO_DIR/tests/bak2dvd.bats
   REPO_DIR="$( cd "$( dirname "${BATS_TEST_DIRNAME}")" >/dev/null 2>&1 && pwd)"
   TOOL_DIR="$( cd "${REPO_DIR}/${TOOL_NAME}" >/dev/null 2>&1 && pwd)"
 }
@@ -13,38 +14,59 @@ setup() {
 
 @test "Confirm the \$REPO_DIR variable is evaluated" {
   cd "${REPO_DIR}" && pwd
+  
   [[ "$status" -eq 0 ]]
 }
 
-@test "Change into the tool directory for ${TOOL_NAME}" {
+# can cd into script dir
+@test "Confirm a valid directory for ${TOOL_NAME}" {
   cd "${TOOL_DIR}" && pwd
+  
   [[ "$status" -eq 0 ]]
 }
 
 @test "Check for latest version of bash-snippets on update" {
   if [[ "$(uname)" == "Linux" ]]; then
     run "${TOOL_DIR}/${TOOL_NAME}" update
+  
     [[ "$status" -eq 0 ]]
-    [[ "$output" = "Bash-Snippets is already the latest version" ]]
+    [ "$output" == "Bash-Snippets is already the latest version" ]
+  fi
+}
+
+@test "The -h option should print usage" {
+  run "${TOOL_DIR}/${TOOL_NAME}" -h
+  
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
   fi
 }
 
 @test "No arguments prints usage instructions" {
   run "${TOOL_DIR}/${TOOL_NAME}"
+  
   [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
-}
-
-@test "The -h option should print usage" {
-  run "${TOOL_DIR}/${TOOL_NAME}" -h
-  [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
 }
 
 @test "Get the tools version with -v" {
   run "${TOOL_DIR}/${TOOL_NAME}" -v
+  
   [[ "$status" -eq 0 ]]
-  [[ "printf '%s\n' ${lines[0]}" =~ 'Version' ]]
+  expected='Version'
+  [[ "${output}" =~ "${expected}" ]]
 }
 
 # Tool specific tests
+

--- a/tests/bak2dvd.bats
+++ b/tests/bak2dvd.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing bak2dvd tool" {
    echo bak2dvd

--- a/tests/bak2dvd.bats
+++ b/tests/bak2dvd.bats
@@ -1,30 +1,50 @@
 #!/usr/bin/env bats
+export TOOL_NAME='bak2dvd'
 
-@test "Testing bak2dvd tool" {
-   echo bak2dvd
+setup() {
+  # $REPO_DIR/tests/skeleton.bats
+  REPO_DIR="$( cd "$( dirname "${BATS_TEST_DIRNAME}")" >/dev/null 2>&1 && pwd)"
+  TOOL_DIR="$( cd "${REPO_DIR}/${TOOL_NAME}" >/dev/null 2>&1 && pwd)"
+}
+
+@test "Testing ${TOOL_NAME} tool" {
+  echo "${TOOL_NAME}"
+}
+
+@test "Confirm the \$REPO_DIR variable is evaluated" {
+  cd "${REPO_DIR}" && pwd
+  [[ "$status" -eq 0 ]]
+}
+
+@test "Change into the tool directory for ${TOOL_NAME}" {
+  cd "${TOOL_DIR}" && pwd
+  [[ "$status" -eq 0 ]]
 }
 
 @test "Check for latest version of bash-snippets on update" {
-  if [[ "$(uname)" == "Linux" ]];then
-  run bak2dvd update
-  [ "$status" -eq 0 ]
-  [ "$output" = "Bash-Snippets is already the latest version" ]
-fi
-}
-
-@test "The -h option should print usage" {
-  if [[ "$(uname)" == "Linux" ]];then
-  run bak2dvd -h
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Bak2dvd" ]
+  if [[ "$(uname)" == "Linux" ]]; then
+    run "${TOOL_DIR}/${TOOL_NAME}" update
+    [[ "$status" -eq 0 ]]
+    [[ "$output" = "Bash-Snippets is already the latest version" ]]
   fi
 }
 
+@test "No arguments prints usage instructions" {
+  run "${TOOL_DIR}/${TOOL_NAME}"
+  [[ "$status" -eq 0 ]]
+  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+}
 
+@test "The -h option should print usage" {
+  run "${TOOL_DIR}/${TOOL_NAME}" -h
+  [[ "$status" -eq 0 ]]
+  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+}
 
 @test "Get the tools version with -v" {
-  run bak2dvd -v
-  [ "$status" -eq 0 ]
-  result=$( echo $(bak2dvd -v) | grep -Eo "Version")
-  [ "$result" = "Version" ]
+  run "${TOOL_DIR}/${TOOL_NAME}" -v
+  [[ "$status" -eq 0 ]]
+  [[ "printf '%s\n' ${lines[0]}" =~ 'Version' ]]
 }
+
+# Tool specific tests

--- a/tests/cheat.bats
+++ b/tests/cheat.bats
@@ -14,38 +14,58 @@ setup() {
 
 @test "Confirm the \$REPO_DIR variable is evaluated" {
   cd "${REPO_DIR}" && pwd
+  
   [[ "$status" -eq 0 ]]
 }
 
-@test "Change into the tool directory for ${TOOL_NAME}" {
+# can cd into script dir
+@test "Confirm a valid directory for ${TOOL_NAME}" {
   cd "${TOOL_DIR}" && pwd
+  
   [[ "$status" -eq 0 ]]
 }
 
 @test "Check for latest version of bash-snippets on update" {
   if [[ "$(uname)" == "Linux" ]]; then
     run "${TOOL_DIR}/${TOOL_NAME}" update
+  
     [[ "$status" -eq 0 ]]
-    [[ "$output" = "Bash-Snippets is already the latest version" ]]
+    [ "$output" == "Bash-Snippets is already the latest version" ]
+  fi
+}
+
+@test "The -h option should print usage" {
+  run "${TOOL_DIR}/${TOOL_NAME}" -h
+  
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
   fi
 }
 
 @test "No arguments prints usage instructions" {
   run "${TOOL_DIR}/${TOOL_NAME}"
+  
   [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
-}
-
-@test "The -h option should print usage" {
-  run "${TOOL_DIR}/${TOOL_NAME}" -h
-  [[ "$status" -eq 0 ]]
-  [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
 }
 
 @test "Get the tools version with -v" {
   run "${TOOL_DIR}/${TOOL_NAME}" -v
+  
   [[ "$status" -eq 0 ]]
-  [[ "printf '%s\n' ${lines[0]}" =~ 'Version' ]]
+  expected='Version'
+  [[ "${output}" =~ "${expected}" ]]
 }
 
 @test "Grabbing information on a programming language (rust)" {

--- a/tests/cheat.bats
+++ b/tests/cheat.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing stocks tool" {
    echo stocks

--- a/tests/cheat.bats
+++ b/tests/cheat.bats
@@ -1,43 +1,45 @@
 #!/usr/bin/env bats
 
-@test "Testing stocks tool" {
-   echo stocks
+@test "Testing cheat tool" {
+   echo cheat
 }
 
 @test "Check for latest version of bash-snippets on update" {
-  if [[ "$(uname)" == "Linux" ]];then
-  run stocks update
-  [ "$status" -eq 0 ]
-  [ "$output" = "Bash-Snippets is already the latest version" ]
-fi
-}
-
-@test "The -h option should print usage" {
-  run stocks -h
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Stocks" ]
+  if [[ "$(uname)" == "Linux" ]]; then
+    run cheat update
+    [ "$status" -eq 0 ]
+    [ "$output" = "Bash-Snippets is already the latest version" ]
+  fi
 }
 
 @test "No arguments prints usage instructions" {
-  run stocks
+  run cheat
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Stocks" ]
+  [ "${lines[0]}" = "Cheat" ]
 }
 
-@test "Get stock info by passing in ticker" {
-  result=$( echo $(stocks AAPL) | grep -Eo "AAPL stock info" )
-  [ "$result" = "AAPL stock info" ]
-
+@test "The -h option should print usage" {
+  run cheat -h
+  [ "$status" -eq 0 ]
+  [ "${lines[0]}" = "Cheat" ]
 }
 
-@test "Get stock info by passing in company" {
-  result=$( echo $(stocks Apple) | grep -Eo "AAPL stock info" )
-  [ "$result" = "AAPL stock info" ]
+@test "Grabbing information on a programming language (rust)" {
+  run cheat rust
+  [ "$status" -eq 0 ]
+  result=$( echo $(cheat rust) | grep -Eo "Rust is a systems" )
+  [ "$result" = "Rust is a systems" ]
+}
+
+
+@test "Testing unkown topic due to misspelling" {
+  result=$( echo $(cheat go operators) | grep -Eo "Unknown" )
+  [ "$result" = "Unknown" ]
 }
 
 @test "Get the tools version with -v" {
-  run stocks -v
+  run cheat -v
   [ "$status" -eq 0 ]
-  result=$( echo $(stocks -v) | grep -Eo "Version")
+  result=$( echo $(cheat -v) | grep -Eo "Version")
   [ "$result" = "Version" ]
 }

--- a/tests/cloudup.bats
+++ b/tests/cloudup.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing cloudup tool" {
    echo cloudup

--- a/tests/crypt.bats
+++ b/tests/crypt.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing crypt tool" {
    echo crypt

--- a/tests/cryptocurrency.bats
+++ b/tests/cryptocurrency.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing cryptocurrency tool" {
    echo cryptocurrency

--- a/tests/currency.bats
+++ b/tests/currency.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing currency tool" {
    echo currency

--- a/tests/geo.bats
+++ b/tests/geo.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing geo tool" {
    echo geo

--- a/tests/meme.bats
+++ b/tests/meme.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing meme tool" {
    echo meme

--- a/tests/movies.bats
+++ b/tests/movies.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing movies tool" {
    echo movies

--- a/tests/newton.bats
+++ b/tests/newton.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing newton tool" {
    echo newton

--- a/tests/qrify.bats
+++ b/tests/qrify.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing qrify tool" {
    echo qrify

--- a/tests/short.bats
+++ b/tests/short.bats
@@ -1,32 +1,90 @@
 #!/usr/bin/env bats
 
-@test "Testing short tool" {
-   echo short
+export TOOL_NAME='short'
+
+setup() {
+  # $REPO_DIR/tests/short.bats
+  REPO_DIR="$( cd "$( dirname "${BATS_TEST_DIRNAME}")" >/dev/null 2>&1 && pwd)"
+  TOOL_DIR="$( cd "${REPO_DIR}/${TOOL_NAME}" >/dev/null 2>&1 && pwd)"
+}
+
+@test "Testing ${TOOL_NAME} tool" {
+  echo "${TOOL_NAME}"
+}
+
+@test "Confirm the \$REPO_DIR variable is evaluated" {
+  cd "${REPO_DIR}" && pwd
+  
+  [[ "$status" -eq 0 ]]
+}
+
+# can cd into script dir
+@test "Confirm a valid directory for ${TOOL_NAME}" {
+  cd "${TOOL_DIR}" && pwd
+  
+  [[ "$status" -eq 0 ]]
 }
 
 @test "Check for latest version of bash-snippets on update" {
-  if [[ "$(uname)" == "Linux" ]];then
-  run short update
-  [ "$status" -eq 0 ]
-  [ "$output" = "Bash-Snippets is already the latest version" ]
-fi
+  if [[ "$(uname)" == "Linux" ]]; then
+    run "${TOOL_DIR}/${TOOL_NAME}" update
+  
+    [[ "$status" -eq 0 ]]
+    [ "$output" == "Bash-Snippets is already the latest version" ]
+  fi
 }
 
 @test "The -h option should print usage" {
-  run short -h
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Short" ]
+  run "${TOOL_DIR}/${TOOL_NAME}" -h
+  
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
 }
 
 @test "No arguments prints usage instructions" {
-  run short
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Short" ]
+  run "${TOOL_DIR}/${TOOL_NAME}"
+  
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
 }
 
 @test "Get the tools version with -v" {
-  run short -v
-  [ "$status" -eq 0 ]
-  result=$( echo $(short -v) | grep -Eo "Version")
-  [ "$result" = "Version" ]
+  run "${TOOL_DIR}/${TOOL_NAME}" -v
+  
+  [[ "$status" -eq 0 ]]
+  expected='Version'
+  [[ "${output}" =~ "${expected}" ]]
 }
+
+# Tool specific tests
+
+@test "Shorten github repo URL" {
+  longurl='https://github.com/alexanderepstein/Bash-Snippets'
+  run "${TOOL_DIR}/${TOOL_NAME}" -s "${longurl}"
+  
+  [[ "$status" -eq 0 ]]
+  expected='http://tinyurl.com/uowfbb5'
+  [[ "${lines[2]}" =~ "${expected}" ]]
+}
+
+@test "Expand tinyurl URL" {
+  shorturl='http://tinyurl.com/uowfbb5'
+  run "${TOOL_DIR}/${TOOL_NAME}" -e "${shorturl}"
+  
+  [[ "$status" -eq 0 ]]
+  expected='https://github.com/alexanderepstein/Bash-Snippets'
+  [[ "${lines[2]}" =~ "${expected}" ]]
+}
+

--- a/tests/short.bats
+++ b/tests/short.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing short tool" {
    echo short

--- a/tests/siteciphers.bats
+++ b/tests/siteciphers.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing siteciphers tool" {
    echo siteciphers

--- a/tests/stocks.bats
+++ b/tests/stocks.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing stocks tool" {
    echo stocks

--- a/tests/taste.bats
+++ b/tests/taste.bats
@@ -4,7 +4,7 @@ export TOOL_NAME='taste'
 export TASTE_API_KEY="290044-Taste-QIQUQKOZ"
 
 setup() {
-  # $REPO_DIR/tests/skeleton.bats
+  # $REPO_DIR/tests/taste.bats
   REPO_DIR="$( cd "$( dirname "${BATS_TEST_DIRNAME}")" >/dev/null 2>&1 && pwd)"
   TOOL_DIR="$( cd "${REPO_DIR}/${TOOL_NAME}" >/dev/null 2>&1 && pwd)"
 }
@@ -13,61 +13,74 @@ setup() {
   echo "${TOOL_NAME}"
 }
 
+@test "Check for latest version of bash-snippets on update" {
+  if [[ "$(uname)" == "Linux" ]]; then
+    run "${TOOL_DIR}/${TOOL_NAME}" update
+
+    [[ "$status" -eq 0 ]]
+    [ "$output" == "Bash-Snippets is already the latest version" ]
+  fi
+}
 
 @test "The -h option should print usage" {
-#  if [[ "$(uname)" == "Darwin" ]]; then
-   run "${TOOL_DIR}/${TOOL_NAME}" -h
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "${TOOL_NAME^}" ]
-#  fi
+  run "${TOOL_DIR}/${TOOL_NAME}" -h
+
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
+}
+
+@test "No arguments prints usage instructions" {
+  run "${TOOL_DIR}/${TOOL_NAME}"
+
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
+}
+
+@test "Get the tools version with -v" {
+  run "${TOOL_DIR}/${TOOL_NAME}" -v
+
+  [[ "$status" -eq 0 ]]
+  expected='Version'
+  [[ "${output}" =~ "${expected}" ]]
 }
 
 @test "Testing short recommendations" {
-  #if [[ "$(uname)" == "Darwin" ]]; then
   run "${TOOL_DIR}/${TOOL_NAME}" 50 Cent
-  [ "$status" -eq 0 ]
+
+  # order of ouput lines changed
+  [[ "$status" -eq 0 ]]
   [ "${lines[0]}" = "===================================" ]
   [ "${lines[1]}" = "G-Unit: music" ]
   [ "${lines[2]}" = "The Game: music" ]
   [ "${lines[3]}" = "Lloyd Banks: music" ]
   [ "${lines[4]}" = "===================================" ]
-  #fi
 }
 
 @test "Testing long recommendations" {
-  #if [[ "$(uname)" == "Darwin" ]]; then
   run "${TOOL_DIR}/${TOOL_NAME}" -i Sublime
-  [ "$status" -eq 0 ]
+
+  [[ "$status" -eq 0 ]]
   expected='Soundsystem is the fifth studio album by 311, released on October 12, 1999. Soundsystem, which was certified Gold by the RIAA,'
   [[ "${output}" =~ "${expected}" ]]
-  #fi
 }
 
 @test "Testing search on item" {
-  #if [[ "$(uname)" == "Darwin" ]]; then
   run "${TOOL_DIR}/${TOOL_NAME}" -s Kendrick Lamar
-  [ "$status" -eq 0 ]
+
+  [[ "$status" -eq 0 ]]
   expected='Kendrick Lamar Duckworth'
   [[ "${output}" =~ "${expected}" ]]
-  #[ "$response" = "Kendrick Lamar Duckworth" ]
-  #fi
 }
 
-@test "No arguments prints usage instructions" {
- # if [[ "$(uname)" == "Darwin" ]]; then
-  #run taste
-  run "${TOOL_DIR}/${TOOL_NAME}"
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "${TOOL_NAME^}" ]
-  #[ "${lines[0]}" = "Taste" ]
-#fi
-}
-
-@test "Get the tools version with -v" {
-  #if [[ "$(uname)" == "Darwin" ]]; then
-  run "${TOOL_DIR}/${TOOL_NAME}" -v
-  [ "$status" -eq 0 ]
-  expected='Version'
-  [[ "${output}" =~ "${expected}" ]]
-  #fi
-}

--- a/tests/taste.bats
+++ b/tests/taste.bats
@@ -1,63 +1,73 @@
 #!/usr/bin/env bats
 
-@test "Testing taste tool" {
-   echo taste
-   export TASTE_API_KEY="290044-Taste-QIQUQKOZ"
+export TOOL_NAME='taste'
+export TASTE_API_KEY="290044-Taste-QIQUQKOZ"
 
+setup() {
+  # $REPO_DIR/tests/skeleton.bats
+  REPO_DIR="$( cd "$( dirname "${BATS_TEST_DIRNAME}")" >/dev/null 2>&1 && pwd)"
+  TOOL_DIR="$( cd "${REPO_DIR}/${TOOL_NAME}" >/dev/null 2>&1 && pwd)"
+}
+
+@test "Testing ${TOOL_NAME} tool" {
+  echo "${TOOL_NAME}"
 }
 
 
 @test "The -h option should print usage" {
-  if [[ "$(uname)" == "Darwin" ]]; then
-  run taste -h
+#  if [[ "$(uname)" == "Darwin" ]]; then
+   run "${TOOL_DIR}/${TOOL_NAME}" -h
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Taste" ]
- fi
+  [ "${lines[0]}" = "${TOOL_NAME^}" ]
+#  fi
 }
 
 @test "Testing short recommendations" {
-  if [[ "$(uname)" == "Darwin" ]]; then
-  run taste 50 Cent
+  #if [[ "$(uname)" == "Darwin" ]]; then
+  run "${TOOL_DIR}/${TOOL_NAME}" 50 Cent
   [ "$status" -eq 0 ]
   [ "${lines[0]}" = "===================================" ]
   [ "${lines[1]}" = "G-Unit: music" ]
-  [ "${lines[2]}" = "Lloyd Banks: music" ]
-  [ "${lines[3]}" = "The Game: music" ]
+  [ "${lines[2]}" = "The Game: music" ]
+  [ "${lines[3]}" = "Lloyd Banks: music" ]
   [ "${lines[4]}" = "===================================" ]
- fi
+  #fi
 }
 
 @test "Testing long recommendations" {
-  if [[ "$(uname)" == "Darwin" ]]; then
-  run taste -i Sublime
+  #if [[ "$(uname)" == "Darwin" ]]; then
+  run "${TOOL_DIR}/${TOOL_NAME}" -i Sublime
   [ "$status" -eq 0 ]
-  response=$(echo $(taste -i Sublime) | grep -Eo "Soundsystem is the fifth studio album by 311, released on October 12, 1999. Soundsystem, which was certified Gold by the RIAA,")
-  [ "$response" = "Soundsystem is the fifth studio album by 311, released on October 12, 1999. Soundsystem, which was certified Gold by the RIAA," ]
-fi
+  expected='Soundsystem is the fifth studio album by 311, released on October 12, 1999. Soundsystem, which was certified Gold by the RIAA,'
+  [[ "${output}" =~ "${expected}" ]]
+  #fi
 }
 
 @test "Testing search on item" {
-  if [[ "$(uname)" == "Darwin" ]]; then
-  run taste -s Kendrick Lamar
+  #if [[ "$(uname)" == "Darwin" ]]; then
+  run "${TOOL_DIR}/${TOOL_NAME}" -s Kendrick Lamar
   [ "$status" -eq 0 ]
-  response=$(echo $(taste -s Kendrick Lamar) | grep -Eo "Kendrick Lamar Duckworth")
-  [ "$response" = "Kendrick Lamar Duckworth" ]
-fi
+  expected='Kendrick Lamar Duckworth'
+  [[ "${output}" =~ "${expected}" ]]
+  #[ "$response" = "Kendrick Lamar Duckworth" ]
+  #fi
 }
 
 @test "No arguments prints usage instructions" {
-  if [[ "$(uname)" == "Darwin" ]]; then
-  run taste
+ # if [[ "$(uname)" == "Darwin" ]]; then
+  #run taste
+  run "${TOOL_DIR}/${TOOL_NAME}"
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Taste" ]
-fi
+  [ "${lines[0]}" = "${TOOL_NAME^}" ]
+  #[ "${lines[0]}" = "Taste" ]
+#fi
 }
 
 @test "Get the tools version with -v" {
-  if [[ "$(uname)" == "Darwin" ]]; then
-  run taste -v
+  #if [[ "$(uname)" == "Darwin" ]]; then
+  run "${TOOL_DIR}/${TOOL_NAME}" -v
   [ "$status" -eq 0 ]
-  result=$( echo $(taste -v) | grep -Eo "Version")
-  [ "$result" = "Version" ]
-fi
+  expected='Version'
+  [[ "${output}" =~ "${expected}" ]]
+  #fi
 }

--- a/tests/taste.bats
+++ b/tests/taste.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing taste tool" {
    echo taste

--- a/tests/todo.bats
+++ b/tests/todo.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing todo tool" {
    echo todo

--- a/tests/transfer.bats
+++ b/tests/transfer.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing transfer tool" {
    echo transfer

--- a/tests/weather.bats
+++ b/tests/weather.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing weather tool" {
    echo weather

--- a/tests/weather.bats
+++ b/tests/weather.bats
@@ -1,34 +1,80 @@
 #!/usr/bin/env bats
 
-@test "Testing weather tool" {
-   echo weather
+export TOOL_NAME='weather'
+
+setup() {
+  # $REPO_DIR/tests/weather.bats
+  REPO_DIR="$( cd "$( dirname "${BATS_TEST_DIRNAME}")" >/dev/null 2>&1 && pwd)"
+  TOOL_DIR="$( cd "${REPO_DIR}/${TOOL_NAME}" >/dev/null 2>&1 && pwd)"
+}
+
+@test "Testing ${TOOL_NAME} tool" {
+  echo "${TOOL_NAME}"
+}
+
+@test "Confirm the \$REPO_DIR variable is evaluated" {
+  cd "${REPO_DIR}" && pwd
+
+  [[ "$status" -eq 0 ]]
+}
+
+# can cd into script dir
+@test "Confirm a valid directory for ${TOOL_NAME}" {
+  cd "${TOOL_DIR}" && pwd
+
+  [[ "$status" -eq 0 ]]
 }
 
 @test "Check for latest version of bash-snippets on update" {
-  if [[ "$(uname)" == "Linux" ]];then
-  run weather update
-  [ "$status" -eq 0 ]
-  [ "$output" = "Bash-Snippets is already the latest version" ]
-fi
+  if [[ "$(uname)" == "Linux" ]]; then
+    run "${TOOL_DIR}/${TOOL_NAME}" update
+
+    [[ "$status" -eq 0 ]]
+    [ "$output" == "Bash-Snippets is already the latest version" ]
+  fi
 }
 
 @test "The -h option should print usage" {
-  run weather -h
-  [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Weather" ]
+  run "${TOOL_DIR}/${TOOL_NAME}" -h
+
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
 }
 
+@test "No arguments prints usage instructions" {
+  run "${TOOL_DIR}/${TOOL_NAME}"
+
+  [[ "$status" -eq 0 ]]
+  # if bash is less than 7 yrs old
+  if ((${BASH_VERSINFO[0]} >= 4)); then
+    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
+  else
+    # or im probably a stoneage mac
+    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
+  fi
+}
+
+@test "Get the tools version with -v" {
+  run "${TOOL_DIR}/${TOOL_NAME}" -v
+
+  [[ "$status" -eq 0 ]]
+  expected='Version'
+  [[ "${output}" =~ "${expected}" ]]
+}
+
+# Tool specific tests
 @test "Testing weather with specified location" {
-  run weather Paramus
+  run "${TOOL_DIR}/${TOOL_NAME}" Paramus
+
   [ "$status" -eq 0 ]
   # API changed
   #[ "${lines[0]}" = "Weather report: Paramus, United States of America" ]
   [ "${lines[0]}" = "Weather report: Paramus" ]
 }
 
-@test "Get the tools version with -v" {
-  run weather -v
-  [ "$status" -eq 0 ]
-  result=$( echo $(weather -v) | grep -Eo "Version")
-  [ "$result" = "Version" ]
-}

--- a/tests/weather.bats
+++ b/tests/weather.bats
@@ -21,7 +21,9 @@ fi
 @test "Testing weather with specified location" {
   run weather Paramus
   [ "$status" -eq 0 ]
-  [ "${lines[0]}" = "Weather report: Paramus, United States of America" ]
+  # API changed
+  #[ "${lines[0]}" = "Weather report: Paramus, United States of America" ]
+  [ "${lines[0]}" = "Weather report: Paramus" ]
 }
 
 @test "Get the tools version with -v" {

--- a/tests/weather.bats
+++ b/tests/weather.bats
@@ -47,17 +47,12 @@ setup() {
   fi
 }
 
-@test "No arguments prints usage instructions" {
+@test "No arguments shows weather at current location" {
   run "${TOOL_DIR}/${TOOL_NAME}"
 
   [[ "$status" -eq 0 ]]
-  # if bash is less than 7 yrs old
-  if ((${BASH_VERSINFO[0]} >= 4)); then
-    [[ "${lines[0]}" = "${TOOL_NAME^}" ]]
-  else
-    # or im probably a stoneage mac
-    [[ "$(echo "${output}" | grep -i "${TOOL_NAME}")" ]]
-  fi
+  expected='Weather report: Lat'
+  [[ "${lines[0]}" =~ "${expected}" ]]
 }
 
 @test "Get the tools version with -v" {

--- a/tests/ytview.bats
+++ b/tests/ytview.bats
@@ -1,4 +1,4 @@
-#!/bin/env bats
+#!/usr/bin/env bats
 
 @test "Testing ytview tool" {
    echo ytview


### PR DESCRIPTION
# :white_check_mark: updates to tests

**Pull Request Label:**
* [x] Bug
* [ ] New feature
* [x] Enhancement
* [ ] New component
* [x] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [x] Have you ran the tests locally with `bats tests`?

-----

## :ambulance: fixes

- [x] :white_check_mark: :green_heart: fix shebang in `tests/*`

    It was `#!/bin/env` now `#!/usr/bin/env`.  The [travis config](.travis.yml)
    masked this by calling `bats` on the  `./tests` directory.

- [x] :bug: :apple: fix bash 3.2 regex comparisons
- [x] :penguin: fix bats output checks

    Using conditional regex checks: `[[ ${output} =~ ${expected} ]]` 

- [x] :alien: update `weather.bats` due to external change

    `wttr` returns "Paramus" and not "Paramus, United States of America" as
    it did previously.

- [x] :speech_balloon: bump version tag in `bak2dvd` to match repo

    Update would never be satisfied.

- [x] :truck: recover `cheats.bats`

    This was overwritten in 0b291d2.  Addresses #184 

## :sparkles: enchancements


- [x] :white_check_mark: add url tests to `short.bats`
- [x] :art: add `skeleton.bats` boilerplate test file 

## :hammer: refactoring

- [x] :hammer: refactor `bak2dvd.bats` from new bats skeleton
- [x] :hammer: refactor `cheat.bats` from new bats skeleton
- [x] :hammer: refactor `short.bats` from new bats skeleton
- [x] :hammer: refactor `taste.bats` from new bats skeleton
- [x] :hammer: refactor `weather.bats` from new bats skeleton
- [x] :pencil2: fix typo in `skeleton`

Not all the tests are refactored.  `skeleton.bats` should reduce the effort.
