### PR TITLE
Solution for Wlan IP address for Mac?

### DIFF
--- a/geo/geo
+++ b/geo/geo
@@ -68,7 +68,7 @@ version() {
 
 # Fetches WAN IP address
 wan_search() {
-  httpGet https://api.ipify.org?format=json | grep -Eo "[0-9.]*"
+  httpGet https://api.ipify.org
 }
 
 # Fetches current LAN IP address


### PR DESCRIPTION
I removed the format=json and the pipe to grep. When I do httpGet https://api.apify.org, I get the IP address and no formatting that I have to clean up.

I ran bats tests. I tested in Mac OSX and an Ubuntu docker container that I have installed. 

I also manually tried 
* `http GET https://api.ipify.org`
* `wget https://api.ipify.org`
* `curl https://api.ipify.org`

I didn't try fetch, but I assume the same.

**Pull Request Label:**
* [x] Bug
* [ ] New feature
* [ ] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [x] Have you ran the tests locally with `bats tests`?

-----
