### PR TITLE
Added bak2dvd to tools

### DIFF
--- a/bash-snippets/bash-snippets
+++ b/bash-snippets/bash-snippets
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Author: Navan Chauhan and Alexander Epstein
-declare -a tools=(cheat cloudup crypt cryptocurrency currency geo lyrics meme movies newton pwned qrify short siteciphers stocks taste todo transfer weather ytview)
+declare -a tools=(bak2dvd cheat cloudup crypt cryptocurrency currency geo lyrics meme movies newton pwned qrify short siteciphers stocks taste todo transfer weather ytview)
 declare -a validTools=()
 currentVersion="1.23.0"
 configuredClient=""


### PR DESCRIPTION
this fixes the issue that bak2dvd was not showing in tools or installation check

**Pull Request Label:**
* [x] Bug
* [ ] New feature
* [ ] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [ ] Have you ran the tests locally with `bats tests`?

-----
