### PR TITLE
Make use of exchangerate-api.com instead of exchagerateapi.io.

### DIFF
--- a/currency/currency
+++ b/currency/currency
@@ -166,7 +166,7 @@ convertCurrency()
   if [[ "$trueBase" == "$exchangeTo" || "$base" == "$trueTarget" ]]; then
     exchangeRate="1"
   else
-    exchangeRate=$(httpGet "https://api.exchangeratesapi.io/latest?base=$trueBase" | grep -Eo "$trueTarget\":[0-9.]*" | grep -Eo "[0-9.]*") > /dev/null
+    exchangeRate=$(httpGet "https://api.exchangerate-api.com/v4/latest/$trueBase" | grep -Eo "$trueTarget\":[0-9.]*" | grep -Eo "[0-9.]*") > /dev/null
   fi
   if ! command -v bc &>/dev/null; then
     exchangeRate=$(echo "$exchangeRate" | grep -Eo "^[0-9]*" )


### PR DESCRIPTION
**Pull Request Label:**
* [X] Bug
* [ ] New feature
* [ ] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [X] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [ ] Have you ran the tests locally with `bats tests`?

-----
Due to `exchagerateapi.io` is now requires an access key, the `currency` script will fail with `syntax error`.
As a remedy, I make use of `exchangerate-api.com` instead.