### PR TITLE
enable redirect flag (-L) with curl in meme script

### DIFF
--- a/meme/meme
+++ b/meme/meme
@@ -24,7 +24,7 @@ getConfiguredClient()
 httpGet()
 {
   case "$configuredClient" in
-    curl)  curl -A curl -s "$@" ;;
+    curl)  curl -A curl -Ls "$@" ;;
     wget)  wget -qO- "$@" ;;
     httpie) http -b GET "$@" ;;
     fetch) fetch -q "$@" ;;


### PR DESCRIPTION
**Pull Request Label:**
* [x] Bug
* [ ] New feature
* [ ] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [x] Have you ran the tests locally with `bats tests`?

-----

A request to `https://memegen.link/foo/bar/baz.jpg` is redirected to  `https://api.memegen.link/foo/bar/baz.jpg`. Since curl doesn't follow redirect responses by default, the meme tool currently fails when using curl. This PR fixes this by enabling the redirect flag (-L) in curl.