### PR TITLE
Changed the ytview file corresponding to change on youtube html sourc…

### DIFF
--- a/ytview/ytview
+++ b/ytview/ytview
@@ -142,6 +142,9 @@ channelview()
   mkdir -p "$HOME"/.cache/ytview/channels/"$channel" || return 1
   httpGet "https://www.youtube.com/user/$channel/videos?hl=en" | grep "Duration" | awk '{print $10 " " $11 " " $12 " " $13 " " $14 " " $15 " " $16 " " $17 " " $18 " " $19 " " $20 " " $21 " " $22 " " $23 " " $24 " " $25 " " $26 " " $27 " " $29}' | sed 's/aria-describedby="description-id.*//' | sed s/title=// | sed 's/"//' | sed 's/"//' | awk '{printf "%s.\t%s\n",NR,$0}'  | sed  s/'&#39;'/"'"/g | sed s/'&amp;'/'and'/g | sed s/\&quot\;/\"/g > "$HOME"/.cache/ytview/channels/"$channel"/titles.txt || return 1
 
+  httpGet "https://www.youtube.com/results?search_query=$search" | grep -oP '"videoRenderer":{[^}]*}[^}]*}[^}]*}[^}]*}[^}]*}}}' | grep -oP '"label":"[^"]*' | sed 's/\"label\":\"//' | cat -n > "$HOME"/.cache/ytview/searches/"$search"/titles.txt || return 1
+
+
   # Get the video urls
   httpGet "https://www.youtube.com/user/$channel/Videos?hl=en" | grep "watch?v=" | awk '{print $6}' | sed s/spf-link// | sed s/href=// | sed 's/"//' | sed 's/"//' | sed '/^\s*$/d' | sed 's/\//https:\/\/www.youtube.com\//' | awk '{printf "%s.\t%s\n",NR,$0}' > "$HOME"/.cache/ytview/channels/"$channel"/urls.txt || return 1
 
@@ -164,12 +167,18 @@ searchview()
   mkdir -p "$HOME"/.cache/ytview/searches/"$search"
 
   #Get video titles
-  httpGet "https://www.youtube.com/results?hl=en&search_query=$search" | grep "Duration" | grep "watch?v=" | awk '{print $13 " " $14 " " $15 " " $16 " " $17 " " $18 " " $19 " " $20 " " $21 " " $22 " " $23 " " $23}' | sed 's/aria-describedby="description-id.*//g' | sed s/title=// | sed 's/"//g' | sed s/spf-link// | sed 's/data-session-link=itct*.//' | sed s/spf-prefetch//g | sed 's/rel=//g' | sed 's/"//' | awk '{printf "%s.\t%s\n",NR,$0}' | sed  s/'&#39;'/"'"/g | sed  s/'&amp;'/'and'/g | sed s/\&quot\;/\"/g > "$HOME"/.cache/ytview/searches/"$search"/titles.txt || return 1
+  #httpGet "https://www.youtube.com/results?hl=en&search_query=$search" | grep "Duration" | grep "watch?v=" | awk '{print $13 " " $14 " " $15 " " $16 " " $17 " " $18 " " $19 " " $20 " " $21 " " $22 " " $23 " " $23}' | sed 's/aria-describedby="description-id.*//g' | sed s/title=// | sed 's/"//g' | sed s/spf-link// | sed 's/data-session-link=itct*.//' | sed s/spf-prefetch//g | sed 's/rel=//g' | sed 's/"//' | awk '{printf "%s.\t%s\n",NR,$0}' | sed  s/'&#39;'/"'"/g | sed  s/'&amp;'/'and'/g | sed s/\&quot\;/\"/g > "$HOME"/.cache/ytview/searches/"$search"/titles.txt || return 1
+
+
+  httpGet "https://www.youtube.com/results?search_query=$search" | grep -oP '"videoRenderer":{[^}]*}[^}]*}[^}]*}[^}]*}[^}]*}}}' | grep -oP '"label":"[^"]*' | sed 's/\"label\":\"//' | cat -n > "$HOME"/.cache/ytview/searches/"$search"/titles.txt || return 1
 
   #Get video urls
-  httpGet "https://www.youtube.com/results?hl=en&search_query=$search" | grep "watch?v=" | awk '{print $5}' | sed s/vve-check// | sed 's/href="/https:\/\/www.youtube.com/' | sed 's/"//' | sed s/class="yt-uix-tile-link"// | sed '/^\s*$/d' | awk '{printf "%s.\t%s\n",NR,$0}' > "$HOME"/.cache/ytview/searches/"$search"/urls.txt || return 1
+  #httpGet "https://www.youtube.com/results?hl=en&search_query=$search" | grep "watch?v=" | awk '{print $5}' | sed s/vve-check// | sed 's/href="/https:\/\/www.youtube.com/' | sed 's/"//' | sed s/class="yt-uix-tile-link"// | sed '/^\s*$/d' | awk '{printf "%s.\t%s\n",NR,$0}' > "$HOME"/.cache/ytview/searches/"$search"/urls.txt || return 1
+
+
+  httpGet "https://www.youtube.com/results?search_query=$search" | grep -oP '"videoRenderer":{[^}]*}[^}]*}[^}]*}[^}]*}[^}]*}}}' | grep -oP '"videoId":"[^"]*' | sed 's/\"videoId\":\"/https:\/\/www.youtube.com\/watch?v=/' > "$HOME"/.cache/ytview/searches/"$search"/urls.txt || return 1
   #Print 20 first video titles for the user to choose from
-  cat "$HOME"/.cache/ytview/searches/"$search"/titles.txt || return 1
+  head -20 "$HOME"/.cache/ytview/searches/"$search"/titles.txt || return 1
 
   #Let the user choose the video number
   read -p "Choose a video: " titlenumber
@@ -179,7 +188,8 @@ searchview()
   fi
 
   #Play the video with your favorite player
-  $player $(sed -n $(echo "$titlenumber")p < "$HOME"/.cache/ytview/searches/"$search"/urls.txt | awk '{print $2}') > /dev/null 2>&1 &
+  $player $(sed -n $(echo "$titlenumber")p < "$HOME"/.cache/ytview/searches/"$search"/urls.txt) > /dev/null 2>&1 &
+  #$player $(sed -n $(echo "$titlenumber")p < "$HOME"/.cache/ytview/searches/"$search"/urls.txt | awk '{print $2}') > /dev/null 2>&1 &
 }
 
 usage()
@@ -194,7 +204,7 @@ Usage: ytview [flag] [string] or ytview [videoToSearch]
   -h  Show the help
   -v  Get the tool version
 Examples:
-  ytview -s Family Guy Chicken Fight
+  ytview -s "Family Guy Chicken Fight"
   ytview -c Numberphile
 EOF
 }
@@ -205,7 +215,7 @@ getConfiguredClient || exit 1
 while getopts "vuc:s:h*:" option; do
   case "${option}" in
     s) if [[ $flag != "channel" ]]; then
-         search=$(printf '%s ' "$@")
+		 search="$OPTARG"
          flag="search"
        else
          echo "Error: search and channel options are mutually exclusive" >&2


### PR DESCRIPTION
…e code

**Pull Request Label:**
* [x] Bug
* [ ] New feature
* [ ] Enhancement
* [ ] New component
* [ ] Typo

**Pull Request Checklist:**
- [x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [x] Have you run the tests locally with `bats tests`?
I ran the tests locally, but the issues weren't related to my changes.
-----

The Problem with ytview was that youtube had changed its HTML structure, but ytview was still expecting the old HTML structure. I tweaked the file ytview to make it work. Now, anyone can search for a topic and watch the video. Though, the channel part still needs to be re-implemented.

Previous Issue and Output:
![Screenshot from 2023-07-11 19-37-11](https://github.com/alexanderepstein/Bash-Snippets/assets/53135486/ae490a08-1a5c-4482-8cfb-589b16b80256)


![Screenshot from 2023-07-11 19-37-32](https://github.com/alexanderepstein/Bash-Snippets/assets/53135486/eb6aa69b-13ab-4137-b222-8211c50982bc)

Output after the change:
![Screenshot from 2023-07-11 19-53-16](https://github.com/alexanderepstein/Bash-Snippets/assets/53135486/40fe9400-bc3c-4de8-bc52-8134a05bfb4b)
![Screenshot from 2023-07-11 19-53-37](https://github.com/alexanderepstein/Bash-Snippets/assets/53135486/dc9ba92e-8030-4ac5-96e3-c62d5266e36c)

Also, initially, the command "search=$(printf '%s ' "$@")" would result in -s being added along with the string to be searched to the search variable, but now only the string to be searched is added. The only compromise is that the user has to enter the string in double or single quotes. And for that, I have changed the help menu. 