### PR TITLE
Fix: correct typo prevent script from stop if response was False in movies

### DIFF
--- a/movies/movies
+++ b/movies/movies
@@ -86,8 +86,14 @@ getMovieInfo()
   movie=$( (echo "$@" | tr " " + ) | sed 's/-d+//g' ) ## format the inputs to use for the api. Added sed command to filter -d flag.
   export PYTHONIOENCODING=utf8 #necessary for python in some cases
   movieInfo=$(httpGet "http://www.omdbapi.com/?t=$movie&apikey=$apiKey") > /dev/null # query the server and get the JSON response
-  checkResponse=$(echo "$movieInfo" | python -c "import sys, json; print json.load(sys.stdin)['Response']" 2> /dev/null)
-  if [[ $checkResponse == "False" ]]; then { echo "No movie found" ; return 1 ;} fi ## check to see if the movie was found
+
+  ## check to see if the movie was found
+  checkResponse=$(echo "$movieInfo" | python -c "from __future__ import print_function; import sys, json; print(json.load(sys.stdin)['Response'])" 2> /dev/null)
+  if [[ $checkResponse == "False" ]]; then
+    echo "$movieInfo" | python -c "from __future__ import print_function; import sys, json; print(json.load(sys.stdin)['Error'])" 2> /dev/null
+    return 1
+  fi
+
   # The rest of the code is just extrapolating the data with python from the JSON response
   title="$(AccessJsonElement "$movieInfo" "Title")"
   year="$(AccessJsonElement "$movieInfo" "Year")"


### PR DESCRIPTION
If the response was false, inform the user what happened example(movie not found or invalid API key)

**Pull Request Label:**
* [x] Bug
* [ ] New feature
* [x] Enhancement
* [ ] New component
* [x] Typo

**Pull Request Checklist:**
- [ x] Have you followed the [guidelines for contributing](https://github.com/alexanderepstein/Bash-Snippets/blob/master/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/alexanderepstein/Bash-Snippets/pulls) for the same fix or component?
- [x] Have you ran the tests locally with `bats tests`?

-----
